### PR TITLE
fix: IconSetItem properties name type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React, { createElement } from "react";
 
 type IconSetItem = {
   properties: {
-    name: "string";
+    name: string;
   };
   icon: { paths: []; attrs: []; width?: string };
 };


### PR DESCRIPTION
Fixes #17 where v2.3.x introduced a faulty type declaration for `IconSetItem.properties.name`.