### PR TITLE
Export IconProps interface

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ type IconSet = {
   icons: IconSetItem[];
 };
 
-interface IconProps extends SVGProps<SVGElement> {
+export interface IconProps extends SVGProps<SVGElement> {
   icon: string;
   size?: string | number;
   title?: string;


### PR DESCRIPTION
Typescript will complain if I want to introduce a default icon size, for example, because I can't point to the correct IconProps.

```
export const Icon: typeof IconComponent = ({ size, ...rest }: IconProps) => (
  <IcoMoon iconSet={IconSet} size={size || 14} {...rest} />
);
```
or
```
export const Icon: typeof IconComponent = (props: IconProps) => <IcoMoon iconSet={IconSet} {...props} size={props.size || 14} />;
```