### PR TITLE
bumped react dependency to include v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.4.1 || ^17.0.0 || ^18.0.0"
+    "react": "^16.4.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
Hi, 
I bumped the React dependency to include v19.0.0. I checked through the breaking changes list at https://react.dev/blog/2024/04/25/react-19-upgrade-guide and did not find anything that would break. 
Would really appreciate getting this merged and published because we could then stop using patch-package to monkey patch the dependency.

Thank you!