### PR TITLE
fix: export type to build in storybook

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ export interface IconProps extends SVGProps<SVGElement> {
   style?: CSSProperties;
 }
 
-interface IcoMoonProps extends IconProps {
+export interface IcoMoonProps extends IconProps {
   iconSet: IconSet;
 }
 


### PR DESCRIPTION
I am creating a component library and using your icon library. When I build it, it is causing this error.

I simulated it here by adding the export for this interface that I made the MR, and the build worked correctly.

<img width="905" alt="image" src="https://github.com/user-attachments/assets/f8d942f8-836b-41ba-8761-3082af2879e5" />
